### PR TITLE
fix: modelform_factory expects exclude or fields arg

### DIFF
--- a/devices/ajax.py
+++ b/devices/ajax.py
@@ -88,13 +88,13 @@ class AddDeviceField(View):
         dform = QueryDict(query_string=unicode(request.POST["form"]).encode('utf-8'))
         classname = dform["classname"]
         if classname == "manufacturer":
-            form = modelform_factory(Manufacturer, form=AddForm)(dform)
+            form = modelform_factory(Manufacturer, exclude=(), form=AddForm)(dform)
         elif classname == "devicetype":
-            form = modelform_factory(Type, form=AddForm)(dform)
+            form = modelform_factory(Type, exclude=(), form=AddForm)(dform)
         elif classname == "room":
-            form = modelform_factory(Room, form=AddForm)(dform)
+            form = modelform_factory(Room, exclude=(), form=AddForm)(dform)
         elif classname == "group":
-            form = modelform_factory(Devicegroup, form=AddForm)(dform)
+            form = modelform_factory(Devicegroup, exclude=(), form=AddForm)(dform)
         else:
             return HttpResponse("")
         data = {}
@@ -132,13 +132,13 @@ class LoadExtraform(View):
     def post(self, request):
         classname = request.POST["classname"]
         if classname == "manufacturer":
-            form = modelform_factory(Manufacturer, form=AddForm)()
+            form = modelform_factory(Manufacturer, exclude=(), form=AddForm)()
         elif classname == "devicetype":
-            form = modelform_factory(Type, form=AddForm)()
+            form = modelform_factory(Type, exclude=(), form=AddForm)()
         elif classname == "room":
-            form = modelform_factory(Room, form=AddForm)()
+            form = modelform_factory(Room, exclude=(), form=AddForm)()
         elif classname == "group":
-            form = modelform_factory(Devicegroup, form=AddForm)()
+            form = modelform_factory(Devicegroup, exclude=(), form=AddForm)()
         else:
             return HttpResponse("")
 


### PR DESCRIPTION
Django 1.8 threw ImproperlyConfigured exception when adding a new device and using modal forms.

Adding `, exclude=(), ` is one way to fix this, there's probably a better way.

See: https://docs.djangoproject.com/en/1.8/ref/forms/models/