### PR TITLE
fix dymo print label modal

### DIFF
--- a/templates/snippets/modals/deviceprintDymoModal.html
+++ b/templates/snippets/modals/deviceprintDymoModal.html
@@ -40,10 +40,11 @@
 
         function loadPrinters() {
             var printers = dymo.label.framework.getPrinters();
+            var printersSelect = $('#printersSelect');
             if (printers.length == 0) {
                 var option = document.createElement('option');
                 option.appendChild(document.createTextNode("No DYMO-Printers found"));
-                printersSelect.appendChild(option);
+                printersSelect.append(option);
                 printButton.disabled = true;
                 return;
             }
@@ -56,9 +57,8 @@
                     var option = document.createElement('option');
                     option.value = printerName;
                     option.appendChild(document.createTextNode(printerName));
-                    printersSelect.appendChild(option);
+                    printersSelect.append(option);
                 }
-                var printerSelect = $('#printerSelect');
                 printersSelect.select2('val', printersSelect.children('option:eq(0)').val());
             }
         }


### PR DESCRIPTION
Printing modal was broken:

+ typo with printersSelect declaration (missing s)
+ variable declaration has to go up
+ when using jquery use append() instead of appendChild()