### PR TITLE
fix department filter in ajax search

### DIFF
--- a/devices/ajax.py
+++ b/devices/ajax.py
@@ -410,10 +410,7 @@ class AjaxSearch(View):
                     value = int(value)
                 except:
                     break
-                if "department__in" in dictionary:
-                    dictionary["department__in"].append(value)
-                else:
-                    dictionary["department__in"] = [value]
+                dictionary["department__in"] = [value]
 
             elif key == "hostname":
                 if len(displayed_columns) < 8:


### PR DESCRIPTION
fixes #248

it doesn't make sense to extend the departments, instead limit to the
requested value