### PR TITLE
Revert "workaround: make search page work"

### DIFF
--- a/static/js/lagerregal.js
+++ b/static/js/lagerregal.js
@@ -56,12 +56,7 @@
             }, 60000 );
         });
 
-        // HACK: the search page overwrites jquery
-        try {
-            $('[data-timeago]').timeago();
-        } catch {}
-        try {
-            $('[data-toggle="popover"]').popover();
-        } catch {}
+        $('[data-timeago]').timeago();
+        $('[data-toggle="popover"]').popover();
     });
 })();

--- a/templates/base.html
+++ b/templates/base.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8"/>
     <meta http-equiv="Content-Security-Policy" content="default-src 'self';
-        script-src 'self' 'unsafe-inline' 'unsafe-eval';
+        script-src 'self' 'unsafe-inline';
         style-src 'self' 'unsafe-inline' http://fonts.googleapis.com https://fonts.googleapis.com;
         connect-src 'self' https://localhost:41951 https://127.0.0.1:41951;
         font-src 'self' http://fonts.gstatic.com https://fonts.gstatic.com" >


### PR DESCRIPTION
This reverts #264. As search has been replaced in #265, the workaround is no longer required.