### PR TITLE
update django-debug-toolbar to 1.10

### DIFF
--- a/dependencies.txt
+++ b/dependencies.txt
@@ -1,7 +1,7 @@
 django < 2.0
 django-reversion >= 2.0.10
 djangorestframework >= 3.6.4
-django-debug-toolbar >= 1.8
+django-debug-toolbar >= 1.10
 Pillow
 django-oauth-toolkit < 1.2.0
 pytz


### PR DESCRIPTION
required since #243. See also #239