### PR TITLE
pin django-select2

### DIFF
--- a/dependencies.txt
+++ b/dependencies.txt
@@ -11,6 +11,6 @@ django-casper
 django-permission
 django_auth_ldap
 django-favicon
-django-select2
+django-select2 < 7.0.0
 psycopg2-binary
 faker


### PR DESCRIPTION
dropped support for django 1.11

https://github.com/applegrew/django-select2/releases/tag/7.0.0