### PR TITLE
replace popup by confirm

### DIFF
--- a/static/js/lagerregal.js
+++ b/static/js/lagerregal.js
@@ -61,9 +61,13 @@
         });
 
         $('[data-timeago]').timeago();
-        $('[data-toggle="popover"]').popover({
-            sanitize: false,
-        });
         $('#id_duedate').datepicker();
+
+        $(document).on('submit', 'form[data-confirm]', function(event) {
+            var msg = $(this).data('confirm');
+            if (!window.confirm(msg)) {
+                event.preventDefault();
+            }
+        });
     });
 })();

--- a/templates/devices/device_detail.html
+++ b/templates/devices/device_detail.html
@@ -93,71 +93,48 @@
                     <li class="dropdown-divider"></li>
                 {% endif %}
                 {% if can_change_device %}
-                    <li class="dropdown-item"><a href="#" id="storagebutton"
-                           data-toggle="popover"
-                           data-html="true"
-                           data-placement="left"
-                           data-title="<span class='text-info'><strong>{% trans "Are you sure?" %}</strong></span>"
-                           data-content='<form action="{% url "device-storage" object.id %}" method="post" class="form-horizontal">{% csrf_token %}<div class="form-group dropdown-cancel"><label for="id_send_mail" class="col-sm-10 control-label">Send room-changed email</label><div class="col-sm-"><input id="id_send_mail" name="send_mail" type="checkbox" class="form-control dropdown-cancel"></div></div><button type="button" class="btn btn-secondary dropdown-cancel" onclick="$(&quot;#storagebutton&quot;).popover(&quot;hide&quot;);">{% trans "Cancel" %}</button><input type="submit" value="{% trans "Yes" %}" class="btn btn-danger pull-right"/></form>'
-                           class="dropdown-cancel"><i class="fa fa-folder"></i> {% trans "Move to storage" %}</a></li>
-                    <li class="dropdown-item"><a href="#"
-                           id="archivebutton"
-                           data-toggle="popover"
-                           data-html="true"
-                           data-placement="left"
-                           data-title="<span class='text-info'><strong>{% trans "Are you sure?" %}</strong></span>"
-                           data-content='<form action="{% url "device-archive" object.id %}" method="post" class="form-horizontal">{% csrf_token %}<button type="button" class="btn btn-secondary dropdown-cancel" onclick="$(&quot;#archivebutton&quot;).popover(&quot;hide&quot;);">{% trans "No" %}</button><input type="submit" value="{% trans "Yes" %}" class="btn btn-danger pull-right"/></form>'
-                           class="dropdown-cancel"><i class="fa fa-folder"></i> {% trans "Archive" %}</a></li>
-                    <li class="dropdown-item"><a href="#"
-                           id="trashbutton"
-                           data-toggle="popover"
-                           data-html="true"
-                           data-placement="left"
-                           data-title="<span class='text-info'><strong>  Are you sure? {%if object.used_in%} This object is still used in <a href='{% url 'device-detail' object.used_in.pk %}'>{{object.used_in}}</a>. {% elif usedset%} This object still uses {% for element in usedset %} <a href='{% url 'device-detail' element.pk %}'> {{element}} </a>{% endfor %} .{% endif %} </strong></span>"
-                           data-content='<form action="{% url "device-trash" object.id %}" method="post" class="form-horizontal">{% csrf_token %}<button type="button" class="btn btn-secondary dropdown-cancel" onclick="$(&quot;#trashbutton&quot;).popover(&quot;hide&quot;);">{% trans "No" %}</button><input type="submit" value="{% trans "Yes" %}" class="btn btn-danger pull-right"/></form>'
-                           class="dropdown-cancel"><i class="fa fa-trash-o"></i> {% trans "Trash" %}</a></li>
+                    <li>
+                        <form action="{% url "device-storage" object.id %}" method="post" data-confirm="{% trans "Are you sure?" %}">
+                            {% csrf_token %}
+                            <button class="dropdown-item"><i class="fa fa-folder"></i> {% trans "Move to storage" %}</button>
+                        </form>
+                    </li>
+                    <li>
+                        <form action="{% url "device-archive" object.id %}" method="post" data-confirm="{% trans "Are you sure?" %}">
+                            {% csrf_token %}
+                            <button class="dropdown-item"><i class="fa fa-folder"></i> {% trans "Archive" %}</button>
+                        </form>
+                    </li>
+                    <li>
+                        <form action="{% url "device-trash" object.id %}" method="post" data-confirm="{% trans "Are you sure?" %} {% if object.used_in %}This object is still used in {{ object.used_in }}.{% elif usedset %}This object still uses {{ usedset|join:"," }}.{% endif %}" class="form-inline">
+                            {% csrf_token %}
+                            <button class="dropdown-item"><i class="fa fa-trash-o"></i> {% trans "Trash" %}</button>
+                        </form>
+                    </li>
                 {% endif %}
                 {% if can_change_device %}
-                    <li class="dropdown-item">
-                        <a href="#"
-                           id="deletebutton"
-                           data-toggle="popover"
-                           data-html="true"
-                           data-placement="left"
-                           data-title="<span class='text-info'><strong>{% trans "are you sure?" %}</strong></span>"
-                           data-content='<form action="{% url "device-delete" object.id %}" method="post" class="form-horizontal">{% csrf_token %}<button type="button" class="btn btn-secondary" onclick="$(&quot;#deletebutton&quot;).popover(&quot;hide&quot;);">{% trans "No" %}</button><input type="submit" value="{% trans "Yes" %}" class="btn btn-danger pull-right"/></form>'
-                           class="dropdown-cancel"><i class="fa fa-times"></i> {% trans "Delete" %}</a>
+                    <li>
+                        <form action="{% url "device-delete" object.id %}" method="post" data-confirm="{% trans "Are you sure?" %}">
+                            {% csrf_token %}
+                            <button class="dropdown-item"><i class="fa fa-times"></i> {% trans "Delete" %}</button>
+                        </form>
                     </li>
                 {% endif %}
             </ul>
         </div>
     {% else %}
         {% if can_change_device and device.archived != None %}
-            <a href="#"
-               id="archivebutton"
-               data-toggle="popover"
-               data-html="true"
-               data-title="<span class='text-info'><strong>{% trans "Are you sure?" %}</strong></span>"
-               data-content='<form action="{% url "device-archive" object.id %}" method="post" class="form-horizontal">{% csrf_token %}<button type="button" class="btn btn-secondary dropdown-cancel" onclick="$(&quot;#archivebutton&quot;).popover(&quot;hide&quot;);">{% trans "No" %}</button><input type="submit" value="{% trans "Yes" %}" class="btn btn-danger pull-right"/></form>'
-               class="btn btn-success btn-sm"
-              >
-                <i class="fa fa-folder-open"></i>
-                {% trans "Unarchive" %}
-            </a>
+            <form action="{% url "device-archive" object.id %}" method="post" data-confirm="{% trans "Are you sure?" %}" class="d-inline-block">
+                {% csrf_token %}
+                <button class="btn btn-success btn-sm"><i class="fa fa-folder-open"></i> {% trans "Unarchive" %}</button>
+            </form>
         {% endif %}
 
         {% if can_change_device and device.trashed != None %}
-            <a href="#"
-               id="trashbutton"
-               data-toggle="popover"
-               data-html="true"
-               data-title="<span class='text-info'><strong>  Are you sure? {%if object.used_in%} This object is still used in <a href='{% url 'device-detail' object.used_in.pk %}'>{{object.used_in}}</a>. {% elif usedset%} This object still uses {% for element in usedset %} <a href='{% url 'device-detail' element.pk %}'> {{element}} </a>{% endfor %} .{% endif %} </strong></span>"
-               data-content='<form action="{% url "device-trash" object.id %}" method="post" class="form-horizontal">{% csrf_token %}<button type="button" class="btn btn-secondary dropdown-cancel"onclick="$(&quot;#trashbutton&quot;).popover(&quot;hide&quot;);">{% trans "No" %}</button><input type="submit" value="{% trans "Yes" %}" class="btn btn-danger pull-right"/></form>'
-               class="btn btn-success btn-sm"
-              >
-                <i class="fa fa-folder-open"></i>
-                {% trans "Remove from Trash" %}
-            </a>
+            <form action="{% url "device-trash" object.id %}" method="post" data-confirm="{% trans "Are you sure?" %}" class="d-inline-block">
+                {% csrf_token %}
+                <button class="btn btn-success btn-sm"><i class="fa fa-folder-open"></i> {% trans "Remove from Trash" %}</button>
+            </form>
         {% endif %}
     {% endif %}
 {% endblock %}

--- a/templates/snippets/deletebutton.html
+++ b/templates/snippets/deletebutton.html
@@ -1,11 +1,6 @@
 {% load i18n %}
 
-<a href="#"
-   id="deletebutton"
-   data-toggle="popover"
-   data-html="true"
-   data-placement="bottom"
-   data-title="<span class='text-info'><strong>{% trans "are you sure?" %}</strong></span>"
-   data-content='<form action="{{ url }}" method="post" class="form-horizontal">{% csrf_token %}<button type="button" class="btn btn-secondary" onclick="$(&quot;#deletebutton&quot;).popover(&quot;hide&quot;);">{% trans "No" %}</button><input type="submit" value="{% trans "Yes" %}" class="btn btn-danger pull-right"/></form>'
-   class="btn btn-danger btn-sm"
-  ><i class="fa fa-trash-o"></i> {% trans "Delete" %}</a>
+<form action="{{ url }}" method="post" data-confirm="{% trans "Are you sure?" %}" class="d-inline-block">
+    {% csrf_token %}
+    <button class="btn btn-danger btn-sm"><i class="fa fa-trash-o"></i> {% trans "Delete" %}</button>
+</form>

--- a/templates/users/department_detail.html
+++ b/templates/users/department_detail.html
@@ -8,7 +8,7 @@
 {% block pullright %}
     {% has_perm 'users.add_department_user' user department as can_add_department_user %}
     {% if can_add_department_user %}
-        <a href="{% url "department-add-user" department.id %}" id="adduserbutton" data-toggle="popover" class="btn btn-success btn-sm">
+        <a href="{% url "department-add-user" department.id %}" id="adduserbutton" class="btn btn-success btn-sm">
             <i class="fa fa-plus"></i> {% trans "Add User" %}
         </a>
     {% endif %}


### PR DESCRIPTION
We have a lot of popups that just ask for a yes/no answer. For that there is a builtin [confirm dialog](https://developer.mozilla.org/en-US/docs/Web/API/Window/confirm). This has several benefits:

- The current popup solution is not actually that great from a UX perspective. For example, the popups don't close when the containing dropdown closes.
- Some inline JS is removed which is great for security (see #241). The workaround from #305 can be removed.
- Accessibility is better.
- Complexity is lower.

Unfortunately bootstrap3 does not support forms/buttons inside dropdowns. So this has to wait for #181.