### PR TITLE
expand tests

### DIFF
--- a/devicegroups/tests.py
+++ b/devicegroups/tests.py
@@ -19,3 +19,26 @@ class DevicegroupTests(TestCase):
         self.assertEqual(str(devicegroup), devicegroup.name)
         self.assertEqual(devicegroup.get_absolute_url(), reverse('devicegroup-detail', kwargs={'pk': devicegroup.pk}))
         self.assertEqual(devicegroup.get_edit_url(), reverse('devicegroup-edit', kwargs={'pk': devicegroup.pk}))
+
+    def test_list_view(self):
+        response = self.client.get('/devicegroups/')
+        self.assertEqual(response.status_code, 200)
+
+    def test_create_view(self):
+        response = self.client.get('/devicegroups/add')
+        self.assertEqual(response.status_code, 200)
+
+    def test_detail_view(self):
+        devicegroup = mommy.make(Devicegroup)
+        response = self.client.get('/devicegroups/view/%i' % devicegroup.pk)
+        self.assertEqual(response.status_code, 200)
+
+    def test_update_view(self):
+        devicegroup = mommy.make(Devicegroup)
+        response = self.client.get('/devicegroups/edit/%i' % devicegroup.pk)
+        self.assertEqual(response.status_code, 200)
+
+    def test_delete_view(self):
+        devicegroup = mommy.make(Devicegroup)
+        response = self.client.get('/devicegroups/delete/%i' % devicegroup.pk)
+        self.assertEqual(response.status_code, 200)

--- a/devices/tests.py
+++ b/devices/tests.py
@@ -39,202 +39,151 @@ class DeviceTests(TestCase):
         self.assertTrue(mommy.make(Device, currentlending=lending_past).is_overdue())
         self.assertFalse(mommy.make(Device, currentlending=lending_future).is_overdue())
 
-    def test_device_list(self):
+    def test_list_view(self):
         mommy.make(Device, _quantity=40)
-        url = reverse("device-list")
-        resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
-        self.assertEqual(len(resp.context["device_list"]), 30)
-        self.assertEqual(resp.context["paginator"].num_pages, 2)
-        url = reverse("device-list", kwargs={"page": 2})
-        resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
 
-    def test_device_detail(self):
+        response = self.client.get('/devices/')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context["device_list"]), 30)
+        self.assertEqual(response.context["paginator"].num_pages, 2)
+
+        response = self.client.get('/devices/page/2')
+        self.assertEqual(response.status_code, 200)
+
+    def test_detail_view(self):
         device = mommy.make(Device)
-        devices = Device.objects.all()
-        device = devices[0]
-        ip = IpAddress(address="127.0.0.1")
-        ip.save()
-        url = reverse("device-detail", kwargs={"pk": device.pk})
-        resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
+        response = self.client.get('/devices/%i/' % device.pk)
+        self.assertEqual(response.status_code, 200)
 
-    def test_device_add(self):
+    def test_create_view(self):
         device = mommy.make(Device, name="used")
-        url = reverse("device-add")
-        resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
-        form = resp.context['form']
+
+        response = self.client.get('/devices/add')
+        self.assertEqual(response.status_code, 200)
+
+        form = response.context['form']
         data = form.initial
         data['uses'] = device.id
         data['name'] = "uses"
-        resp = self.client.post(url, data)
-        device = Device.objects.filter(name='used')[0]
+        response = self.client.post('/devices/add', data)
+        device.refresh_from_db()
         self.assertEqual(device.used_in.name, 'uses')
 
-    def test_device_edit(self):
+    def test_update_view(self):
         device = mommy.make(Device)
-        url = reverse("device-edit", kwargs={"pk": device.pk})
-        resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
+        response = self.client.get('/devices/%i/edit/' % device.pk)
+        self.assertEqual(response.status_code, 200)
 
-    def test_device_delete(self):
+    def test_delete_view(self):
         device = mommy.make(Device)
-        devices = Device.objects.all()
-        device = devices[0]
-        url = reverse("device-delete", kwargs={"pk": device.pk})
-        resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
+        response = self.client.get('/devices/%i/delete/' % device.pk)
+        self.assertEqual(response.status_code, 200)
 
-    def test_device_archive(self):
-        device = mommy.make(Device)
-        devices = Device.objects.all()
-        device = devices[0]
-        archiveurl = reverse("device-archive", kwargs={"pk": device.pk})
-        resp = self.client.post(archiveurl)
-        self.assertEqual(resp.status_code, 302)
-        url = reverse("device-detail", kwargs={"pk": device.pk})
-        resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
-        self.assertIsNotNone(resp.context["device"].archived)
+    def test_archive_view(self):
+        device = mommy.make(Device, archived=None)
 
-        resp = self.client.post(archiveurl)
-        self.assertEqual(resp.status_code, 302)
-        resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
-        self.assertIsNone(resp.context["device"].archived)
+        response = self.client.post('/devices/%i/archive/' % device.pk)
+        self.assertEqual(response.status_code, 302)
+        device.refresh_from_db()
+        self.assertIsNotNone(device.archived)
 
-    def test_device_trash(self):
-        device = mommy.make(Device)
-        devices = Device.objects.all()
-        device = devices[0]
-        trashurl = reverse("device-trash", kwargs={"pk": device.pk})
-        resp = self.client.post(trashurl)
-        self.assertEqual(resp.status_code, 302)
-        url = reverse("device-detail", kwargs={"pk": device.pk})
-        resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
-        self.assertIsNotNone(resp.context["device"].trashed)
+        response = self.client.post('/devices/%i/archive/' % device.pk)
+        self.assertEqual(response.status_code, 302)
+        device.refresh_from_db()
+        self.assertIsNone(device.archived)
 
-        resp = self.client.post(trashurl)
-        self.assertEqual(resp.status_code, 302)
-        resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
-        self.assertIsNone(resp.context["device"].trashed)
+    def test_trash_view(self):
+        device = mommy.make(Device, trashed=None)
 
-    def test_device_trash_sets_child_used_in_to_none(self):
+        response = self.client.post('/devices/%i/trash/' % device.pk)
+        self.assertEqual(response.status_code, 302)
+        device.refresh_from_db()
+        self.assertIsNotNone(device.trashed)
+
+        response = self.client.post('/devices/%i/trash/' % device.pk)
+        self.assertEqual(response.status_code, 302)
+        device.refresh_from_db()
+        self.assertIsNone(device.trashed)
+
+    def test_trash_view_sets_child_used_in_to_none(self):
         device = mommy.make(Device)
         used_device = mommy.make(Device, used_in=device)
-        trashurl = reverse('device-trash', kwargs={'pk': device.pk})
-        self.client.post(trashurl)
-        used_device = Device.objects.filter(pk=used_device.pk)[0]
+        self.client.post('/devices/%i/trash/' % device.pk)
+        used_device.refresh_from_db()
         self.assertIsNone(used_device.used_in)
 
-    def test_device_trash_sets_self_used_in_to_none(self):
+    def test_trash_view_sets_self_used_in_to_none(self):
         device = mommy.make(Device, _fill_optional=['used_in'])
-        trashurl = reverse("device-trash", kwargs={'pk': device.pk})
-        self.client.post(trashurl)
-        device = Device.objects.filter(pk=device.pk)[0]
+        self.client.post('/devices/%i/trash/' % device.pk)
+        device.refresh_from_db()
         self.assertIsNone(device.used_in)
 
-    def test_device_trash_returns_lending(self):
+    def test_trash_view_returns_lending(self):
         lending = mommy.make(Lending, _fill_optional=['device', 'owner'])
         lending.device.currentlending = lending
         lending.device.save()
-        trashurl = reverse("device-trash", kwargs={"pk": lending.device.pk})
-        self.client.post(trashurl)
+        self.client.post('/devices/%i/trash/' % lending.device.pk)
         lending.refresh_from_db()
         self.assertIsNotNone(lending.returndate)
 
-    def test_device_inventoried(self):
+    def test_inventoried_view(self):
         device = mommy.make(Device)
-        devices = Device.objects.all()
-        device = devices[0]
-        url = reverse("device-inventoried", kwargs={"pk": device.pk})
-        resp = self.client.post(url)
-        self.assertEqual(resp.status_code, 302)
-        url = reverse("device-detail", kwargs={"pk": device.pk})
-        resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
-        self.assertIsNotNone(resp.context["device"].inventoried)
+        response = self.client.post('/devices/%i/inventoried/' % device.pk)
+        self.assertEqual(response.status_code, 302)
+        device.refresh_from_db()
+        self.assertIsNotNone(device.inventoried)
 
-    def test_device_bookmark(self):
+    def test_bookmark_view(self):
         device = mommy.make(Device)
-        devices = Device.objects.all()
-        device = devices[0]
-        bookmarkurl = reverse("device-trash", kwargs={"pk": device.pk})
-        url = reverse("device-detail", kwargs={"pk": device.pk})
-        resp = self.client.post(bookmarkurl)
-        self.assertEqual(resp.status_code, 302)
-        resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
-        self.assertIsNotNone(resp.context["device"].trashed)
 
-        resp = self.client.post(bookmarkurl)
-        self.assertEqual(resp.status_code, 302)
-        resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
-        self.assertIsNone(resp.context["device"].trashed)
+        response = self.client.post('/devices/%i/bookmark/' % device.pk)
+        self.assertEqual(response.status_code, 302)
+        device.refresh_from_db()
+        self.assertEqual(device.bookmarkers.count(), 1)
 
-    def test_device_ipaddress(self):
+        response = self.client.post('/devices/%i/bookmark/' % device.pk)
+        self.assertEqual(response.status_code, 302)
+        device.refresh_from_db()
+        self.assertEqual(device.bookmarkers.count(), 0)
+
+    def test_ipaddress_view(self):
         device = mommy.make(Device)
-        ip = IpAddress(address="127.0.0.1")
-        ip.save()
-        devices = Device.objects.all()
-        device = devices[0]
-        url = reverse("device-ipaddress", kwargs={"pk": device.pk})
-        resp = self.client.post(url, {"ipaddresses": [ip.pk], "device": device.pk})
-        self.assertEqual(resp.status_code, 302)
-        deviceurl = reverse("device-detail", kwargs={"pk": device.pk})
-        resp = self.client.get(deviceurl)
-        self.assertEqual(resp.status_code, 200)
-        self.assertEqual(len(resp.context["device"].ipaddress_set.all()), 1)
+        ip = mommy.make(IpAddress)
 
-        url = reverse("device-ipaddress-remove", kwargs={"pk": device.pk, "ipaddress": ip.pk})
-        resp = self.client.post(url)
-        self.assertEqual(resp.status_code, 302)
-        resp = self.client.get(deviceurl)
-        self.assertEqual(resp.status_code, 200)
-        self.assertEqual(len(resp.context["device"].ipaddress_set.all()), 0)
+        response = self.client.post('/devices/%i/ipaddress/' % device.pk, {
+            'ipaddresses': [ip.pk],
+            'device': device.pk,
+        })
+        self.assertEqual(response.status_code, 302)
+        device.refresh_from_db()
+        self.assertEqual(device.ipaddress_set.count(), 1)
 
-    def test_device_lending_list(self):
+        response = self.client.post('/devices/%i/ipaddress/%i/remove' % (device.pk, ip.pk))
+        self.assertEqual(response.status_code, 302)
+        device.refresh_from_db()
+        self.assertEqual(device.ipaddress_set.count(), 0)
+
+    def test_lending_list_view(self):
         lending = mommy.make(Lending)
         device = mommy.make(Device, currentlending=lending)
-        url = reverse("device-lending-list", kwargs={"pk": device.pk})
-        resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
+        response = self.client.get('/devices/%i/lending/' % device.pk)
+        self.assertEqual(response.status_code, 200)
 
-    def test_device_lend(self):
-        device = mommy.make(Device, archived=None)
-        room = mommy.make(Room)
-        room.save()
-        lending = mommy.make(Lending)
-        lending.save()
-        devices = Device.objects.all()
-        device = devices[0]
-        url = reverse("device-lend")
-        resp = self.client.post(url)
-        self.assertEqual(resp.status_code, 200)
-        deviceurl = reverse("device-detail", kwargs={"pk": device.pk})
-        resp = self.client.get(deviceurl)
-        self.assertEqual(resp.status_code, 200)
+    def test_lend_view(self):
+        response = self.client.post('/devices/lend/')
+        self.assertEqual(response.status_code, 200)
 
-    def test_device_return(self):
+    def test_return_view_device(self):
         device = mommy.make(Device)
-        devices = Device.objects.all()
-        device = devices[0]
+        lending = mommy.make(Lending, device=device)
+        response = self.client.post('/devices/return/%i' % lending.pk)
+        self.assertEqual(response.status_code, 302)
+
+    def test_return_view_user(self):
         user = mommy.make(Lageruser)
-
         lending = mommy.make(Lending, owner=user)
-        url = reverse("device-return", kwargs={"lending": lending.id})
-        resp = self.client.post(url)
-        self.assertEqual(resp.status_code, 302)
-
-        lending2 = mommy.make(Lending, device=device)
-        url = reverse("device-return", kwargs={"lending": lending2.id})
-        resp = self.client.post(url)
-        self.assertEqual(resp.status_code, 302)
+        response = self.client.post('/devices/return/%i' % lending.pk)
+        self.assertEqual(response.status_code, 302)
 
 
 class BuildingTests(TestCase):
@@ -245,51 +194,40 @@ class BuildingTests(TestCase):
 
     def test_building_creation(self):
         building = mommy.make(Building)
-        building.save()
         self.assertTrue(isinstance(building, Building))
         self.assertEqual(str(building), building.name)
         self.assertEqual(building.get_absolute_url(), reverse('building-detail', kwargs={'pk': building.pk}))
         self.assertEqual(building.get_edit_url(), reverse('building-edit', kwargs={'pk': building.pk}))
 
-    def test_building_list(self):
+    def test_list_view(self):
         mommy.make(Building, _quantity=40)
-        url = reverse("building-list")
-        resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
-        self.assertEqual(len(resp.context["building_list"]), 30)
-        self.assertEqual(resp.context["paginator"].num_pages, 2)
-        url = reverse("building-list", kwargs={"page": 2})
-        resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
 
-    def test_building_detail(self):
+        response = self.client.get('/buildings/')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context["building_list"]), 30)
+        self.assertEqual(response.context["paginator"].num_pages, 2)
+
+        response = self.client.get('/buildings/2')
+        self.assertEqual(response.status_code, 200)
+
+    def test_detail_view(self):
         building = mommy.make(Building)
-        buildings = Building.objects.all()
-        building = buildings[0]
-        url = reverse("building-detail", kwargs={"pk": building.pk})
-        resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
+        response = self.client.get('/buildings/view/%i' % building.pk)
+        self.assertEqual(response.status_code, 200)
 
-    def test_building_add(self):
-        url = reverse("building-add")
-        resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
+    def test_create_view(self):
+        response = self.client.get('/buildings/add')
+        self.assertEqual(response.status_code, 200)
 
-    def test_building_edit(self):
+    def test_update_view(self):
         building = mommy.make(Building)
-        buildings = Building.objects.all()
-        building = buildings[0]
-        url = reverse("building-edit", kwargs={"pk": building.pk})
-        resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
+        response = self.client.get('/buildings/edit/%i' % building.pk)
+        self.assertEqual(response.status_code, 200)
 
-    def test_building_delete(self):
+    def test_delete_view(self):
         building = mommy.make(Building)
-        buildings = Building.objects.all()
-        building = buildings[0]
-        url = reverse("building-delete", kwargs={"pk": building.pk})
-        resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
+        response = self.client.get('/buildings/delete/%i' % building.pk)
+        self.assertEqual(response.status_code, 200)
 
 
 class RoomTests(TestCase):
@@ -309,45 +247,35 @@ class RoomTests(TestCase):
         self.assertEqual(room.get_absolute_url(), reverse('room-detail', kwargs={'pk': room.pk}))
         self.assertEqual(room.get_edit_url(), reverse('room-edit', kwargs={'pk': room.pk}))
 
-    def test_room_list(self):
+    def test_list_view(self):
         mommy.make(Room, _quantity=40)
-        url = reverse("room-list")
-        resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
-        self.assertEqual(len(resp.context["room_list"]), 30)
-        self.assertEqual(resp.context["paginator"].num_pages, 2)
-        url = reverse("room-list", kwargs={"page": 2})
-        resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
 
-    def test_room_detail(self):
+        response = self.client.get('/rooms/')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context["room_list"]), 30)
+        self.assertEqual(response.context["paginator"].num_pages, 2)
+
+        response = self.client.get('/rooms/2')
+        self.assertEqual(response.status_code, 200)
+
+    def test_detail_view(self):
         room = mommy.make(Room)
-        rooms = Room.objects.all()
-        room = rooms[0]
-        url = reverse("room-detail", kwargs={"pk": room.pk})
-        resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
+        response = self.client.get('/rooms/view/%i' % room.pk)
+        self.assertEqual(response.status_code, 200)
 
-    def test_room_add(self):
-        url = reverse("room-add")
-        resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
+    def test_create_view(self):
+        response = self.client.get('/rooms/add')
+        self.assertEqual(response.status_code, 200)
 
-    def test_room_edit(self):
+    def test_update_view(self):
         room = mommy.make(Room)
-        rooms = Room.objects.all()
-        room = rooms[0]
-        url = reverse("room-edit", kwargs={"pk": room.pk})
-        resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
+        response = self.client.get('/rooms/edit/%i' % room.pk)
+        self.assertEqual(response.status_code, 200)
 
-    def test_room_delete(self):
+    def test_delete_view(self):
         room = mommy.make(Room)
-        rooms = Room.objects.all()
-        room = rooms[0]
-        url = reverse("room-delete", kwargs={"pk": room.pk})
-        resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
+        response = self.client.get('/rooms/delete/%i' % room.pk)
+        self.assertEqual(response.status_code, 200)
 
 
 class ManufacturerTests(TestCase):
@@ -364,45 +292,35 @@ class ManufacturerTests(TestCase):
                          reverse('manufacturer-detail', kwargs={'pk': manufacturer.pk}))
         self.assertEqual(manufacturer.get_edit_url(), reverse('manufacturer-edit', kwargs={'pk': manufacturer.pk}))
 
-    def test_manufacturer_list(self):
+    def test_list_view(self):
         mommy.make(Manufacturer, _quantity=40)
-        url = reverse("manufacturer-list")
-        resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
-        self.assertEqual(len(resp.context["manufacturer_list"]), 30)
-        self.assertEqual(resp.context["paginator"].num_pages, 2)
-        url = reverse("manufacturer-list", kwargs={"page": 2})
-        resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
 
-    def test_manufacturer_detail(self):
+        response = self.client.get('/manufacturers/')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context["manufacturer_list"]), 30)
+        self.assertEqual(response.context["paginator"].num_pages, 2)
+
+        response = self.client.get('/manufacturers/page/2')
+        self.assertEqual(response.status_code, 200)
+
+    def test_detail_view(self):
         manufacturer = mommy.make(Manufacturer)
-        manufacturers = Manufacturer.objects.all()
-        manufacturer = manufacturers[0]
-        url = reverse("manufacturer-detail", kwargs={"pk": manufacturer.pk})
-        resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
+        response = self.client.get('/manufacturers/view/%i' % manufacturer.pk)
+        self.assertEqual(response.status_code, 200)
 
-    def test_manufacturer_add(self):
-        url = reverse("manufacturer-add")
-        resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
+    def test_create_view(self):
+        response = self.client.get('/manufacturers/add')
+        self.assertEqual(response.status_code, 200)
 
-    def test_manufacturer_edit(self):
+    def test_update_view(self):
         manufacturer = mommy.make(Manufacturer)
-        manufacturers = Manufacturer.objects.all()
-        manufacturer = manufacturers[0]
-        url = reverse("manufacturer-edit", kwargs={"pk": manufacturer.pk})
-        resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
+        response = self.client.get('/manufacturers/edit/%i' % manufacturer.pk)
+        self.assertEqual(response.status_code, 200)
 
-    def test_manufacturer_delete(self):
+    def test_delete_view(self):
         manufacturer = mommy.make(Manufacturer)
-        manufacturers = Manufacturer.objects.all()
-        manufacturer = manufacturers[0]
-        url = reverse("manufacturer-delete", kwargs={"pk": manufacturer.pk})
-        resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
+        response = self.client.get('/manufacturers/delete/%i' % manufacturer.pk)
+        self.assertEqual(response.status_code, 200)
 
 
 class TemplateTests(TestCase):
@@ -423,37 +341,30 @@ class TemplateTests(TestCase):
             'devicetype': template.devicetype,
         })
 
-    def test_template_list(self):
+    def test_list_view(self):
         mommy.make(Template, _quantity=40)
-        url = reverse("template-list")
-        resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
-        self.assertEqual(len(resp.context["template_list"]), 30)
-        self.assertEqual(resp.context["paginator"].num_pages, 2)
-        url = reverse("template-list", kwargs={"page": 2})
-        resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
 
-    def test_template_add(self):
-        url = reverse("template-add")
-        resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
+        response = self.client.get('/devices/templates/')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context["template_list"]), 30)
+        self.assertEqual(response.context["paginator"].num_pages, 2)
 
-    def test_template_edit(self):
+        response = self.client.get('/devices/templates/2')
+        self.assertEqual(response.status_code, 200)
+
+    def test_create_view(self):
+        response = self.client.get('/devices/templates/add')
+        self.assertEqual(response.status_code, 200)
+
+    def test_update_view(self):
         template = mommy.make(Template)
-        templates = Template.objects.all()
-        template = templates[0]
-        url = reverse("template-edit", kwargs={"pk": template.pk})
-        resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
+        response = self.client.get('/devices/templates/%i/edit/' % template.pk)
+        self.assertEqual(response.status_code, 200)
 
-    def test_template_delete(self):
+    def test_delete_view(self):
         template = mommy.make(Template)
-        templates = Template.objects.all()
-        template = templates[0]
-        url = reverse("template-delete", kwargs={"pk": template.pk})
-        resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
+        response = self.client.get('/devices/templates/%i/delete/' % template.pk)
+        self.assertEqual(response.status_code, 200)
 
 
 class NoteTests(TestCase):

--- a/devicetags/tests.py
+++ b/devicetags/tests.py
@@ -1,9 +1,12 @@
+import unittest
+
 from django.test.client import Client
 from django.test import TestCase
 from django.urls import reverse
 
 from model_mommy import mommy
 
+from devices.models import Device
 from devicetags.models import Devicetag
 from users.models import Lageruser
 
@@ -20,3 +23,36 @@ class DevicetagsTests(TestCase):
         # there is no devicetag detail view
         self.assertEqual(tag.get_absolute_url(), reverse('devicetag-edit', kwargs={'pk': tag.pk}))
         self.assertEqual(tag.get_edit_url(), reverse('devicetag-edit', kwargs={'pk': tag.pk}))
+
+    def test_list_view(self):
+        response = self.client.get('/devicetags/')
+        self.assertEqual(response.status_code, 200)
+
+    def test_create_view(self):
+        response = self.client.get('/devicetags/add')
+        self.assertEqual(response.status_code, 200)
+
+    def test_update_view(self):
+        tag = mommy.make(Devicetag)
+        response = self.client.get('/devicetags/edit/%i' % tag.pk)
+        self.assertEqual(response.status_code, 200)
+
+    def test_delete_view(self):
+        tag = mommy.make(Devicetag)
+        response = self.client.get('/devicetags/delete/%i' % tag.pk)
+        self.assertEqual(response.status_code, 200)
+
+    @unittest.skip('failing')
+    def test_devicetags_view(self):
+        device = mommy.make(Device)
+        tag = mommy.make(Devicetag)
+        device.tags.add(tag)
+        response = self.client.get('/devices/%i/tags/' % tag.pk)
+        self.assertEqual(response.status_code, 200)
+
+    def test_remove_view(self):
+        device = mommy.make(Device)
+        tag = mommy.make(Devicetag)
+        device.tags.add(tag)
+        response = self.client.get('/devices/%i/tags/%i' % (device.pk, tag.pk))
+        self.assertEqual(response.status_code, 200)

--- a/devicetags/tests.py
+++ b/devicetags/tests.py
@@ -8,7 +8,7 @@ from devicetags.models import Devicetag
 from users.models import Lageruser
 
 
-class DevitagsTests(TestCase):
+class DevicetagsTests(TestCase):
     def setUp(self):
         self.client = Client()
         Lageruser.objects.create_superuser('test', 'test@test.com', 'test')

--- a/devicetypes/tests.py
+++ b/devicetypes/tests.py
@@ -53,3 +53,9 @@ class TypeTests(TestCase):
         devicetype = mommy.make(Type)
         response = self.client.get('/types/delete/%i' % devicetype.pk)
         self.assertEqual(response.status_code, 200)
+
+    def test_merge_view(self):
+        devicetype1 = mommy.make(Type)
+        devicetype2 = mommy.make(Type)
+        response = self.client.get('/types/merge/%i/%i' % (devicetype1.pk, devicetype2.pk))
+        self.assertEqual(response.status_code, 200)

--- a/devicetypes/tests.py
+++ b/devicetypes/tests.py
@@ -11,83 +11,45 @@ from users.models import Lageruser
 class TypeTests(TestCase):
 
     def setUp(self):
-        '''method for setting up a client for testing'''
         self.client = Client()
         Lageruser.objects.create_superuser('test', 'test@test.com', "test")
         self.client.login(username="test", password="test")
 
     def test_type_creation(self):
-        '''method for testing the functionality of creating a new devicetype'''
-        # creating an instance of Type and testing if created instance is instance of Type
         devicetype = mommy.make(Type)
         self.assertTrue(isinstance(devicetype, Type))
-
-        # testing naming
         self.assertEqual(str(devicetype), devicetype.name)
-
-        # testing creation of absolute and relative url
         self.assertEqual(devicetype.get_absolute_url(), reverse('type-detail', kwargs={'pk': devicetype.pk}))
         self.assertEqual(devicetype.get_edit_url(), reverse('type-edit', kwargs={'pk': devicetype.pk}))
 
-    def test_type_list(self):
-        '''method for testing the presentation and reachability of the list of devicestypes over several pages'''
+    def test_list_view(self):
         mommy.make(Type, _quantity=40)
-
-        # testing if loading of devicetype-list-page was successful (statuscode 2xx)
-        url = reverse("type-list")
-        resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
+        response = self.client.get('/types/')
+        self.assertEqual(response.status_code, 200)
 
         # testing the presentation of only 30 results of query on one page
-        self.assertEqual(len(resp.context["type_list"]), 30)
-        self.assertEqual(resp.context["paginator"].num_pages, 2)
+        self.assertEqual(len(response.context["type_list"]), 30)
+        self.assertEqual(response.context["paginator"].num_pages, 2)
 
         # testing the successful loading of second page of devicetype-list (statuscode 2xx)
-        url = reverse("type-list", kwargs={"page": 2})
-        resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
+        response = self.client.get('/types/2')
+        self.assertEqual(response.status_code, 200)
 
-    def test_type_detail(self):
-        '''method for testing the reachability of existing devicetypes'''
-        # querying all devices and choose first one to test
+    def test_detail_view(self):
         devicetype = mommy.make(Type)
-        devicetypes = Type.objects.all()
-        devicetype = devicetypes[0]
+        response = self.client.get('/types/view/%i' % devicetype.pk)
+        self.assertEqual(response.status_code, 200)
 
-        # test successful loading of detail-view of chossen devicetype (first one, statuscode 2xx)
-        url = reverse("type-detail", kwargs={"pk": devicetype.pk})
-        resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
+    def test_create_view(self):
+        response = self.client.get('/types/add')
+        self.assertEqual(response.status_code, 200)
 
-    def test_type_add(self):
-        '''method for testing adding a devicetype'''
-        # testing successful loading of devicetype-page of added device (statuscode 2xx)
-        url = reverse("type-add")
-        resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
-
-    def test_type_edit(self):
-        '''method for testing the functionality of editing a devicetype'''
+    def test_update_view(self):
         devicetype = mommy.make(Type)
+        response = self.client.get('/types/edit/%i' % devicetype.pk)
+        self.assertEqual(response.status_code, 200)
 
-        # querying all devicetypes and choose first one
-        devicetypes = Type.objects.all()
-        devicetype = devicetypes[0]
-
-        # testing successful loading of edited devicetype-detail-page (statuscode 2xx)
-        url = reverse("type-edit", kwargs={"pk": devicetype.pk})
-        resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
-
-    def test_type_delete(self):
-        '''method for testing the functionality of deleting a devicetype'''
+    def test_delete_view(self):
         devicetype = mommy.make(Type)
-
-        # querying all devices and choose first one
-        devicetypes = Type.objects.all()
-        devicetype = devicetypes[0]
-
-        # testing successful loading of devicetype-page after deletion (statuscode 2xx)
-        url = reverse("type-edit", kwargs={"pk": devicetype.pk})
-        resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
+        response = self.client.get('/types/delete/%i' % devicetype.pk)
+        self.assertEqual(response.status_code, 200)

--- a/history/tests.py
+++ b/history/tests.py
@@ -1,3 +1,4 @@
+from django.contrib.contenttypes.models import ContentType
 from django.test.client import Client
 from django.test import TestCase
 
@@ -12,6 +13,16 @@ class HistoryTests(TestCase):
         self.client = Client()
         self.admin = Lageruser.objects.create_superuser('test', 'test@test.com', "test")
         self.client.login(username="test", password="test")
+
+    def test_global_view(self):
+        response = self.client.get('/history/global/')
+        self.assertEqual(response.status_code, 200)
+
+    def test_list_view(self):
+        content_type = ContentType.objects.get(model='device')
+        device = mommy.make(Device)
+        response = self.client.get('/history/%i/%i' % (content_type.pk, device.pk))
+        self.assertEqual(response.status_code, 200)
 
     def test_detail_view(self):
         device = mommy.make(Device)

--- a/history/tests.py
+++ b/history/tests.py
@@ -1,5 +1,4 @@
 from django.test.client import Client
-from django.urls import reverse
 from django.test import TestCase
 
 from model_mommy import mommy
@@ -14,14 +13,12 @@ class HistoryTests(TestCase):
         self.admin = Lageruser.objects.create_superuser('test', 'test@test.com', "test")
         self.client.login(username="test", password="test")
 
-    def test_history_detail(self):
-        mommy.make(Device)
-        devices = Device.objects.all()
-        device = devices[0]
-        url = reverse("device-edit", kwargs={"pk": device.pk})
-        resp = self.client.post(url, data={"name": "test", "creator": self.admin.pk})
-        self.assertEqual(resp.status_code, 302)
-
-        url = reverse("history-detail", kwargs={"pk": 1})
-        resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
+    def test_detail_view(self):
+        device = mommy.make(Device)
+        response = self.client.post('/devices/%i/edit/' % device.pk, data={
+            'name': 'test',
+            'creator': self.admin.pk,
+        })
+        self.assertEqual(response.status_code, 302)
+        response = self.client.get('/history/version/1')
+        self.assertEqual(response.status_code, 200)

--- a/locations/tests.py
+++ b/locations/tests.py
@@ -19,3 +19,32 @@ class SectionTests(TestCase):
         self.assertEqual(str(section), section.name)
         self.assertEqual(section.get_absolute_url(), reverse('section-detail', kwargs={'pk': section.pk}))
         self.assertEqual(section.get_edit_url(), reverse('section-edit', kwargs={'pk': section.pk}))
+
+    def test_list_view(self):
+        response = self.client.get('/sections/')
+        self.assertEqual(response.status_code, 200)
+
+    def test_create_view(self):
+        response = self.client.get('/sections/add')
+        self.assertEqual(response.status_code, 200)
+
+    def test_detail_view(self):
+        section = mommy.make(Section)
+        response = self.client.get('/sections/view/%i' % section.pk)
+        self.assertEqual(response.status_code, 200)
+
+    def test_update_view(self):
+        section = mommy.make(Section)
+        response = self.client.get('/sections/edit/%i' % section.pk)
+        self.assertEqual(response.status_code, 200)
+
+    def test_delete_view(self):
+        section = mommy.make(Section)
+        response = self.client.get('/sections/delete/%i' % section.pk)
+        self.assertEqual(response.status_code, 200)
+
+    def test_merge_view(self):
+        section1 = mommy.make(Section)
+        section2 = mommy.make(Section)
+        response = self.client.get('/sections/merge/%i/%i' % (section1.pk, section2.pk))
+        self.assertEqual(response.status_code, 200)

--- a/mail/tests.py
+++ b/mail/tests.py
@@ -23,6 +23,29 @@ class TestMailTemplate(TestCase):
         self.assertEqual(template.get_absolute_url(), reverse('mail-detail', kwargs={'pk': template.pk}))
         self.assertEqual(template.get_edit_url(), reverse('mail-edit', kwargs={'pk': template.pk}))
 
+    def test_list_view(self):
+        response = self.client.get('/mails/')
+        self.assertEqual(response.status_code, 200)
+
+    def test_create_view(self):
+        response = self.client.get('/mails/add')
+        self.assertEqual(response.status_code, 200)
+
+    def test_detail_view(self):
+        template = mommy.make(MailTemplate)
+        response = self.client.get('/mails/view/%i' % template.pk)
+        self.assertEqual(response.status_code, 200)
+
+    def test_update_view(self):
+        template = mommy.make(MailTemplate)
+        response = self.client.get('/mails/edit/%i' % template.pk)
+        self.assertEqual(response.status_code, 200)
+
+    def test_delete_view(self):
+        template = mommy.make(MailTemplate)
+        response = self.client.get('/mails/delete/%i' % template.pk)
+        self.assertEqual(response.status_code, 200)
+
 
 class TestMailTemplateRecipient(TestCase):
     def setUp(self):

--- a/main/tests.py
+++ b/main/tests.py
@@ -1,10 +1,21 @@
+from django.test.client import Client
 from django.test import TestCase
 
 from main.models import get_progresscolor
+from users.models import Lageruser
 
 
 class TestMethods(TestCase):
+    def setUp(self):
+        self.client = Client()
+        Lageruser.objects.create_superuser("test", "test@test.com", "test")
+        self.client.login(username="test", password="test")
+
     def test_progresscolor(self):
         self.assertEqual(get_progresscolor(91), "danger")
         self.assertEqual(get_progresscolor(90), "warning")
         self.assertEqual(get_progresscolor(59), "success")
+
+    def test_home_view(self):
+        response = self.client.get('/')
+        self.assertEqual(response.status_code, 200)

--- a/network/models.py
+++ b/network/models.py
@@ -27,6 +27,7 @@ class IpAddress(models.Model):
         permissions = (
             ("read_ipaddress", _("Can read IP-Address")),
         )
+        ordering = ['address']
 
     def get_absolute_url(self):
         return reverse('ipaddress-detail', kwargs={'pk': self.pk})

--- a/network/tests.py
+++ b/network/tests.py
@@ -1,3 +1,5 @@
+import unittest
+
 from django.test.client import Client
 from django.urls import reverse
 from django.test import TestCase
@@ -10,79 +12,51 @@ from network.models import IpAddress
 
 class IpAddressTests(TestCase):
     def setUp(self):
-        '''method for setting up a client for testing'''
         self.client = Client()
-        Lageruser.objects.create_superuser("test", "test@test.com", 'test')
+        self.admin = Lageruser.objects.create_superuser("test", "test@test.com", 'test')
         self.client.login(username="test", password="test")
 
-    def test_IpAddress_creation(self):
-        '''method for testing the functionality of creating a new IpAddress'''
-        # creating an instance of IpAddress and testing if created instance is instance of IpAddress
+    def test_creation_view(self):
         address = mommy.make(IpAddress)
         self.assertTrue(isinstance(address, IpAddress))
-
-        # testing creation of absolute and relative url
         self.assertEqual(address.get_absolute_url(), reverse('ipaddress-detail', kwargs={'pk': address.pk}))
 
-    def test_IpAddress_list(self):
-        '''method for testing the presentation and reachability of the list of IpAdresses over several pages'''
+    def test_list_view(self):
         mommy.make(IpAddress, _quantity=40)
 
         # testing if loading of device-list-page was successful (statuscode 2xx)
-        url = reverse("ipaddress-list")
-        resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
+        response = self.client.get('/ipaddresses/')
+        self.assertEqual(response.status_code, 200)
 
         # testing the presentation of only 30 results of query on one page
-        self.assertEqual(len(resp.context["ipaddress_list"]), 30)
-        self.assertEqual(resp.context["paginator"].num_pages, 2)
+        self.assertEqual(len(response.context["ipaddress_list"]), 30)
+        self.assertEqual(response.context["paginator"].num_pages, 2)
 
         # testing the successful loading of second page of ipadresses-list (statuscode 2xx)
-        url = reverse("ipaddress-list", kwargs={"page": 2})
-        resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
+        response = self.client.get('/ipaddresses/page/2')
+        self.assertEqual(response.status_code, 200)
 
-    def test_IpAddress_detail(self):
-        '''method for testing the reachability of existing devices'''
-        # querying all devices and choose first one to test
+    def test_create_view(self):
+        response = self.client.get('/ipaddresses/add')
+        self.assertEqual(response.status_code, 200)
+
+    def test_detail_view(self):
         address = mommy.make(IpAddress)
-        addresses = IpAddress.objects.all()
-        address = addresses[0]
+        response = self.client.get('/ipaddresses/view/%i' % address.pk)
+        self.assertEqual(response.status_code, 200)
 
-        # test successful loading of detail-view of chossen IpAddress (first one, statuscode 2xx)
-        url = reverse("ipaddress-detail", kwargs={"pk": address.pk})
-        resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
-
-    def test_IpAddress_add(self):
-        '''method for testing adding a Ipaddress'''
-        # testing successful loading of Ipaddress-page of added device (statuscode 2xx)
-        url = reverse("ipaddress-add")
-        resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
-
-    def test_IpAddress_edit(self):
-        '''method for testing the functionality of editing a IpAddress'''
+    def test_update_view(self):
         address = mommy.make(IpAddress)
+        response = self.client.get('/ipaddresses/edit/%i' % address.pk)
+        self.assertEqual(response.status_code, 200)
 
-        # querying all devices and choose first one
-        addresses = IpAddress.objects.all()
-        address = addresses[0]
-
-        # testing successful loading of edited ipaddress-detail-page (statuscode 2xx)
-        url = reverse("ipaddress-edit", kwargs={"pk": address.pk})
-        resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
-
-    def test_IpAddress_delete(self):
-        '''method for testing the functionality of deleting a IpAddress'''
+    @unittest.skip('missing template')
+    def test_delete_view(self):
         address = mommy.make(IpAddress)
+        response = self.client.get('/ipaddresses/delete/%i' % address.pk)
+        self.assertEqual(response.status_code, 200)
 
-        # querying all devices and choose first one
-        addresses = IpAddress.objects.all()
-        address = addresses[0]
-
-        # testing successful loading of ipaddress-page after deletion (statuscode 2xx)
-        url = reverse("ipaddress-edit", kwargs={"pk": address.pk})
-        resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
+    @unittest.skip('failing')
+    def test_user_view(self):
+        response = self.client.get('/users/view/%i/ipaddress/' % self.admin.pk)
+        self.assertEqual(response.status_code, 200)

--- a/users/models.py
+++ b/users/models.py
@@ -45,6 +45,7 @@ class Lageruser(AbstractUser):
         permissions = (
             ("read_user", _("Can read User")),
         )
+        ordering = ['username']
 
     def get_absolute_url(self):
         return reverse('userprofile', kwargs={'pk': self.pk})

--- a/users/tests.py
+++ b/users/tests.py
@@ -1,10 +1,14 @@
+import unittest
+
 from django.test.client import Client
 from django.test import TestCase
 from django.urls import reverse
 
 from model_mommy import mommy
 
-from users.models import Lageruser, Department
+from users.models import Department
+from users.models import DepartmentUser
+from users.models import Lageruser
 
 
 class LageruserTests(TestCase):
@@ -22,6 +26,23 @@ class LageruserTests(TestCase):
         user1.clean()
         self.assertEqual(user1.expiration_date, None)
 
+    def test_list_view(self):
+        response = self.client.get('/users/')
+        self.assertEqual(response.status_code, 200)
+
+    def test_detail_view(self):
+        user = mommy.make(Lageruser)
+        response = self.client.get('/users/view/%i' % user.pk)
+        self.assertEqual(response.status_code, 200)
+
+    def test_profile_view(self):
+        response = self.client.get('/profile/')
+        self.assertEqual(response.status_code, 200)
+
+    def test_settings_view(self):
+        response = self.client.get('/settings/')
+        self.assertEqual(response.status_code, 200)
+
 
 class DepartmentTests(TestCase):
     def setUp(self):
@@ -32,3 +53,37 @@ class DepartmentTests(TestCase):
     def test_department_creation(self):
         department = mommy.make(Department)
         self.assertEqual(str(department), department.name)
+
+    def test_list_view(self):
+        response = self.client.get('/departments/')
+        self.assertEqual(response.status_code, 200)
+
+    def test_create_view(self):
+        response = self.client.get('/departments/add')
+        self.assertEqual(response.status_code, 200)
+
+    def test_detail_view(self):
+        department = mommy.make(Department)
+        response = self.client.get('/departments/view/%i' % department.pk)
+        self.assertEqual(response.status_code, 200)
+
+    @unittest.skip('failing')
+    def test_update_view(self):
+        department = mommy.make(Department)
+        response = self.client.get('/departments/edit/%i' % department.pk)
+        self.assertEqual(response.status_code, 200)
+
+    def test_delete_view(self):
+        department = mommy.make(Department)
+        response = self.client.get('/departments/delete/%i' % department.pk)
+        self.assertEqual(response.status_code, 200)
+
+    def test_adduser_view(self):
+        department = mommy.make(Department)
+        response = self.client.get('/departments/adduser/%i' % department.pk)
+        self.assertEqual(response.status_code, 200)
+
+    def test_removeuser_view(self):
+        departmentuser = mommy.make(DepartmentUser)
+        response = self.client.get('/departments/removeuser/%i' % departmentuser.pk)
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
related to #31.

I expanded the tests, mostly to aid refactoring. I used the following guidelines:

- Only do simple checks for now: Do a GET request and check the status code.
- Cover all views (except for API/AJAX)
- Avoid logic in tests (e.g. do not use `reverse()` for URLs)
- Skip failing tests (so we can fix them one by one)

This should allow us to detect crashes and dead code with little effort.

Coverage increased from 58% to 67%.