### PR TITLE
WIP: Replace ldap import script

### DIFF
--- a/users/__init__.py
+++ b/users/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'users.apps.UsersConfig'

--- a/users/apps.py
+++ b/users/apps.py
@@ -1,0 +1,10 @@
+from django.apps import AppConfig
+
+
+class UsersConfig(AppConfig):
+    name = 'users'
+
+    def ready(self):
+        from django_auth_ldap.backend import populate_user
+        from .signals import populate_main_department
+        populate_user.connect(populate_main_department)

--- a/users/signals.py
+++ b/users/signals.py
@@ -1,0 +1,24 @@
+import re
+
+from django.conf import settings
+
+from .models import Department
+from .models import DepartmentUser
+
+
+def get_department_name(ldap_user):
+    value = ldap_user.attrs[settings.AUTH_LDAP_DEPARTMENT_FIELD]
+    return re.findall(settings.AUTH_LDAP_DEPARTMENT_REGEX, value)[-1]
+
+
+def populate_main_department(user, ldap_user, **kwargs):
+    department_name = get_department_name(ldap_user)
+    department, __ = Department.objects.get_or_create(name=department_name)
+
+    user.main_department = department
+    user.save()
+
+    if user.main_department not in user.departments.all():
+        DepartmentUser.objects.create(
+            user=user, department=user.main_department, role="m"
+        )


### PR DESCRIPTION
I was looking at `ldapimport.py` and couldn't really figure out why it is there. As far as I could see, it does three things:

- Import users from LDAP. That is not necessary because django-auth-ldap creates users on demand.
- Mark expired users as inactive. That is not necessary (assuming that LDAP blocks login of expired users).
- Create departments on demand and make sure that `user.main_department` is also included in `user.departments`.

I think the better approach for most of this is using the [`populate_user`](https://django-auth-ldap.readthedocs.io/en/latest/reference.html?highlight=signals#django_auth_ldap.backend.populate_user) signal. This branch contains a rough implementation. It is hard to say whether it works correctly without the rest of the LDAP config (which is not contained in this repo).