### PR TITLE
allow blank Device.operation_system

### DIFF
--- a/devices/migrations/0013_auto_20200509_1148.py
+++ b/devices/migrations/0013_auto_20200509_1148.py
@@ -13,6 +13,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='device',
             name='operating_system',
-            field=models.CharField(choices=[('win', 'Windows'), ('mac', 'macOS'), ('linux', 'Linux')], max_length=10, null=True),
+            field=models.CharField(blank=True, choices=[('win', 'Windows'), ('mac', 'macOS'), ('linux', 'Linux')], max_length=10, null=True),
         ),
     ]

--- a/devices/models.py
+++ b/devices/models.py
@@ -120,7 +120,7 @@ class Device(models.Model):
     bookmarkers = models.ManyToManyField(Lageruser, through=Bookmark, related_name="bookmarks", blank=True)
 
     data_provider = models.CharField(max_length=20, blank=True)
-    operating_system = models.CharField(max_length=10, choices=settings.OPERATING_SYSTEMS, null=True)
+    operating_system = models.CharField(max_length=10, choices=settings.OPERATING_SYSTEMS, null=True, blank=True)
 
     department = models.ForeignKey(Department, null=True, blank=True, related_name="devices", on_delete=models.SET_NULL)
     is_private = models.BooleanField(default=False)


### PR DESCRIPTION
it is ok to edit the migration in this case because blank has no impact on the database