### PR TITLE
Draft: port CI config to github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,16 +7,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-      with:
-        python-version: '3.8'
+    - name: python
+      run: |
+        sudo apt-get install python3 python3-ldap
     - name: flake8
       run: |
         pip install flake8
         flake8 --config=setup.cfg
     - name: test
       run: |
-        sudo apt-get install python3-ldap
         pip install -r requirements.txt
         cp Lagerregal/template_development.py Lagerregal/settings.py
         python manage.py test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,7 @@ jobs:
         flake8 --config=setup.cfg
     - name: test
       run: |
+        sudo apt-get install python3-ldap
         pip install -r requirements.txt
         cp Lagerregal/template_development.py Lagerregal/settings.py
         python manage.py test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,64 @@
+# we test outside of docker, because it is just so much faster
+# Docker-related errors will pop up in develop branch and can be fixed then
+
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+    - name: flake8
+      run: |
+        pip install flake8
+        flake8 --config=setup.cfg
+    - name: test
+      run: |
+        pip install -r requirements.txt
+        cp Lagerregal/template_development.py Lagerregal/settings.py
+        python manage.py test
+  release_develop:
+    if: github.event.branch == 'develop'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/setup-qemu-action@v1
+      - uses: docker/setup-buildx-action@v1
+      - uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: mpib/Lagerregal:develop
+  release_master:
+    if: github.event.branch == 'master'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/setup-qemu-action@v1
+      - uses: docker/setup-buildx-action@v1
+      - uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: mpib/Lagerregal:latest
+  release_demo:
+    if: github.event.branch == 'master'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/setup-qemu-action@v1
+      - uses: docker/setup-buildx-action@v1
+      - uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - uses: docker/build-push-action@v2
+        with:
+          file: demo/Dockerfile
+          push: true
+          tags: mpib/Lagerregal:demo


### PR DESCRIPTION
I tried to port the existing travis config to github actions. Not sure how well this went. The test job should be fine, but everything related to docker is in a very rough state. For example, I didn't know how to integrate the test command in the docker jobs.

In general, github actions feel very verbose and bloated. The documentation was not very helpful either. But maybe I just haven't found the right chapter.

@phillipthelen do you have experience with this?