### PR TITLE
Presumably fix typos for core puppet provider facts

### DIFF
--- a/devicedata/providers/puppet.py
+++ b/devicedata/providers/puppet.py
@@ -36,7 +36,7 @@ class PuppetDeviceInfo(BaseDeviceInfo):
         entries = self.find_entries("fqdn")
         if len(entries) > 0:
             hostname = build_full_hostname(self.device)
-            if entries[0].raw_value["hostId"] != hostname:
+            if entries[0].raw_value != hostname:
                 self.formatted_entries.append(FormattedDeviceInfoEntry(_("Hostname"), "<span class='text-warning'>"
                                                                        + entries[0].raw_value + "</span>"))
             else:
@@ -89,7 +89,7 @@ class PuppetDeviceInfo(BaseDeviceInfo):
         formatted_controllers = []
         device_addresses = self.device.ipaddress_set.all()
         for controller in controllers:
-            if any(elem.address in controller["ipAddress"] for elem in device_addresses):
+            if any(elem.address in controller["ip"] for elem in device_addresses):
                 formatted_controllers.append("{0} {1}".format(controller["identifier"], controller["ip"]))
             else:
                 formatted_controllers.append(


### PR DESCRIPTION
I looked into the broken provider functionality on production today and identified a couple of minor mistakes. Some of them have been fixed by the dynamic import in develop, but these two are still a problem. `hostId` and `ipAddress` do not exist in puppet world and assume they are just copy/paste issues from the opsi provider.