### PR TITLE
Fix device list link when main department is set

### DIFF
--- a/templates/snippets/widgets/bookmarks.html
+++ b/templates/snippets/widgets/bookmarks.html
@@ -24,8 +24,6 @@
     </table>
 
     <div class="card-footer text-right">
-        {% with dep=user.main_department|default:"all" %}
-            <a href="{% url 'device-list' %}?department={{ dep|iriencode }}&filter=bookmark&sorting=name">{% trans "More…" %}</a>
-        {% endwith %}
+        <a href="{% url 'device-list' %}?filter=bookmark&sorting=name">{% trans "More…" %}</a>
     </div>
 {% endblock %}

--- a/templates/snippets/widgets/newestdevices.html
+++ b/templates/snippets/widgets/newestdevices.html
@@ -27,8 +27,6 @@
         </tbody>
     </table>
     <div class="card-footer text-right">
-        {% with dep=user.main_department|default:"all" %}
-            <a href="{% url 'device-list' %}?department={{ dep|iriencode }}&filter=active&sorting=-created_at">{% trans "More…" %}</a>
-        {% endwith %}
+        <a href="{% url 'device-list' %}?filter=active&sorting=-created_at">{% trans "More…" %}</a>
     </div>
 {% endblock %}

--- a/templates/snippets/widgets/overdue.html
+++ b/templates/snippets/widgets/overdue.html
@@ -40,8 +40,6 @@
         </tbody>
     </table>
     <div class="card-footer text-right">
-        {%  with dep=user.main_department|default:"all" %}
-            <a href="{% url 'device-list' %}?department={{ dep|iriencode }}&filter=overdue&sorting=name">{% trans "More…" %}</a>
-        {% endwith %}
+        <a href="{% url 'device-list' %}?filter=overdue&sorting=name">{% trans "More…" %}</a>
     </div>
 {% endblock %}

--- a/templates/snippets/widgets/returnsoon.html
+++ b/templates/snippets/widgets/returnsoon.html
@@ -37,8 +37,6 @@
         </tbody>
     </table>
     <div class="card-footer text-right">
-        {% with dep=user.main_department|default:"all" %}
-            <a href="{% url 'device-list' %}?department={{ dep|iriencode }}&filter=returnsoon&sorting=name">{% trans "More…" %}</a>
-        {% endwith %}
+        <a href="{% url 'device-list' %}?filter=returnsoon&sorting=name">{% trans "More…" %}</a>
     </div>
 {% endblock %}

--- a/templates/snippets/widgets/shorttermdevices.html
+++ b/templates/snippets/widgets/shorttermdevices.html
@@ -31,8 +31,6 @@
         </tbody>
     </table>
     <div class="card-footer text-right">
-        {% with dep=user.main_department|default:"all" %}
-            <a href="{% url 'device-list' %}?department={{ dep|iriencode }}&filter=temporary&sorting=name">{% trans "More…" %}</a>
-        {% endwith %}
+        <a href="{% url 'device-list' %}?filter=temporary&sorting=name">{% trans "More…" %}</a>
     </div>
 {% endblock %}


### PR DESCRIPTION
Currently the "More…" button on widgets trigger

```
Traceback (most recent call last):
  File "/home/mk/work/src/Lagerregal/.venv/lib/python3.9/site-packages/django/core/handlers/exception.py", line 47, in inner
    response = get_response(request)
  File "/home/mk/work/src/Lagerregal/.venv/lib/python3.9/site-packages/django/core/handlers/base.py", line 181, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/home/mk/work/src/Lagerregal/.venv/lib/python3.9/site-packages/django/views/generic/base.py", line 70, in view
    return self.dispatch(request, *args, **kwargs)
  File "/home/mk/work/src/Lagerregal/.venv/lib/python3.9/site-packages/django/contrib/auth/mixins.py", line 104, in dispatch
    return super().dispatch(request, *args, **kwargs)
  File "/home/mk/work/src/Lagerregal/.venv/lib/python3.9/site-packages/django/views/generic/base.py", line 98, in dispatch
    return handler(request, *args, **kwargs)
  File "/home/mk/work/src/Lagerregal/.venv/lib/python3.9/site-packages/django/views/generic/list.py", line 142, in get
    self.object_list = self.get_queryset()
  File "/home/mk/work/src/Lagerregal/devices/views.py", line 162, in get_queryset
    devices = get_devices(self.request.user, self.viewfilter, self.departmentfilter, self.viewsorting)
  File "/home/mk/work/src/Lagerregal/devices/views.py", line 124, in get_devices
    raise ValueError
ValueError
```

when the current user has a main department set.